### PR TITLE
[Java] integrate dubbo black/white list with fury checker

### DIFF
--- a/src/main/java/org/furyio/serialization/dubbo/BaseFurySerialization.java
+++ b/src/main/java/org/furyio/serialization/dubbo/BaseFurySerialization.java
@@ -6,10 +6,12 @@ import io.fury.memory.MemoryBuffer;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.Optional;
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.serialize.ObjectInput;
 import org.apache.dubbo.common.serialize.ObjectOutput;
 import org.apache.dubbo.common.serialize.Serialization;
+import org.apache.dubbo.rpc.model.FrameworkModel;
 
 /**
  * Fury serialization framework integration with dubbo.
@@ -21,11 +23,26 @@ public abstract class BaseFurySerialization implements Serialization {
 
   public ObjectOutput serialize(URL url, OutputStream output) throws IOException {
     Tuple2<Fury, MemoryBuffer> tuple2 = getFury();
-    return new FuryObjectOutput(tuple2.f0, tuple2.f1, output);
+    Fury fury = tuple2.f0;
+    FuryCheckerListener checkerListener = getCheckerListener(url);
+    fury.getClassResolver().setClassChecker(checkerListener.getChecker());
+    fury.getClassResolver().setSerializerFactory(checkerListener);
+    return new FuryObjectOutput(fury, tuple2.f1, output);
   }
 
   public ObjectInput deserialize(URL url, InputStream input) throws IOException {
     Tuple2<Fury, MemoryBuffer> tuple2 = getFury();
-    return new FuryObjectInput(tuple2.f0, tuple2.f1, input);
+    Fury fury = tuple2.f0;
+    FuryCheckerListener checkerListener = getCheckerListener(url);
+    fury.getClassResolver().setClassChecker(checkerListener.getChecker());
+    return new FuryObjectInput(fury, tuple2.f1, input);
+  }
+
+  private static FuryCheckerListener getCheckerListener(URL url) {
+    return Optional.ofNullable(url)
+        .map(URL::getOrDefaultFrameworkModel)
+        .orElseGet(FrameworkModel::defaultModel)
+        .getBeanFactory()
+        .getBean(FuryCheckerListener.class);
   }
 }

--- a/src/main/java/org/furyio/serialization/dubbo/FuryCheckerListener.java
+++ b/src/main/java/org/furyio/serialization/dubbo/FuryCheckerListener.java
@@ -1,0 +1,75 @@
+package org.furyio.serialization.dubbo;
+
+import io.fury.Fury;
+import io.fury.exception.InsecureException;
+import io.fury.resolver.AllowListChecker;
+import io.fury.serializer.Serializer;
+import io.fury.serializer.SerializerFactory;
+import java.io.Serializable;
+import java.util.Set;
+import org.apache.dubbo.common.utils.AllowClassNotifyListener;
+import org.apache.dubbo.common.utils.SerializeCheckStatus;
+import org.apache.dubbo.common.utils.SerializeSecurityManager;
+import org.apache.dubbo.rpc.model.FrameworkModel;
+
+@SuppressWarnings("rawtypes")
+public class FuryCheckerListener implements AllowClassNotifyListener, SerializerFactory {
+  private final SerializeSecurityManager securityManager;
+  private final AllowListChecker checker;
+  private volatile boolean checkSerializable;
+
+  public FuryCheckerListener(FrameworkModel frameworkModel) {
+    checker = new AllowListChecker();
+    securityManager =
+        frameworkModel.getBeanFactory().getOrRegisterBean(SerializeSecurityManager.class);
+    securityManager.registerListener(this);
+  }
+
+  @Override
+  public void notifyPrefix(Set<String> allowedList, Set<String> disAllowedList) {
+    for (String prefix : allowedList) {
+      checker.allowClass(prefix);
+    }
+    for (String prefix : disAllowedList) {
+      checker.disallowClass(prefix);
+    }
+  }
+
+  @Override
+  public void notifyCheckStatus(SerializeCheckStatus status) {
+    switch (status) {
+      case DISABLE:
+        checker.setCheckLevel(AllowListChecker.CheckLevel.DISABLE);
+        return;
+      case WARN:
+        checker.setCheckLevel(AllowListChecker.CheckLevel.WARN);
+        return;
+      case STRICT:
+        checker.setCheckLevel(AllowListChecker.CheckLevel.STRICT);
+        return;
+      default:
+        throw new UnsupportedOperationException("Unsupported check level " + status);
+    }
+  }
+
+  @Override
+  public void notifyCheckSerializable(boolean checkSerializable) {
+    this.checkSerializable = checkSerializable;
+  }
+
+  public AllowListChecker getChecker() {
+    return checker;
+  }
+
+  public boolean isCheckSerializable() {
+    return checkSerializable;
+  }
+
+  @Override
+  public Serializer createSerializer(Fury fury, Class<?> cls) {
+    if (checkSerializable && !Serializable.class.isAssignableFrom(cls)) {
+      throw new InsecureException(String.format("%s is not Serializable", cls));
+    }
+    return null;
+  }
+}

--- a/src/main/java/org/furyio/serialization/dubbo/FuryScopeModelInitializer.java
+++ b/src/main/java/org/furyio/serialization/dubbo/FuryScopeModelInitializer.java
@@ -1,0 +1,21 @@
+package org.furyio.serialization.dubbo;
+
+import org.apache.dubbo.common.beans.factory.ScopeBeanFactory;
+import org.apache.dubbo.rpc.model.ApplicationModel;
+import org.apache.dubbo.rpc.model.FrameworkModel;
+import org.apache.dubbo.rpc.model.ModuleModel;
+import org.apache.dubbo.rpc.model.ScopeModelInitializer;
+
+public class FuryScopeModelInitializer implements ScopeModelInitializer {
+  @Override
+  public void initializeFrameworkModel(FrameworkModel frameworkModel) {
+    ScopeBeanFactory beanFactory = frameworkModel.getBeanFactory();
+    beanFactory.registerBean(FuryCheckerListener.class);
+  }
+
+  @Override
+  public void initializeApplicationModel(ApplicationModel applicationModel) {}
+
+  @Override
+  public void initializeModuleModel(ModuleModel moduleModel) {}
+}

--- a/src/main/resources/META-INF/dubbo/internal/org.apache.dubbo.rpc.model.ScopeModelInitializer
+++ b/src/main/resources/META-INF/dubbo/internal/org.apache.dubbo.rpc.model.ScopeModelInitializer
@@ -1,0 +1,2 @@
+fury=org.furyio.serialization.dubbo.FuryScopeModelInitializer
+fury-compatible=org.furyio.serialization.dubbo.FuryScopeModelInitializer


### PR DESCRIPTION
This PR integrates dubbo black/white list with fury class checker to ensure deserialization security.

We need this feature before we release `dubbo-serialization-fury`